### PR TITLE
fix sanitizer to prevent <code>...</code> tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -269,7 +269,7 @@
                  */
                 formatProposalTitle(title) {
                     // Escape HTML.
-                    const titleEscaped = title.replace(/&/g, "&amp;").replace(/ < /g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#039;");
+                    const titleEscaped = title.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#039;").replace(/`/g, "&#096;");
                     if (titleEscaped.includes("`")) {
                         let isInCodeTag = false;
                         return Array.prototype.map.call(titleEscaped, (character) => {


### PR DESCRIPTION
title now render properly.
Before:

- Expose < code > get_reaction_force < /code> and < code > get_reaction_torque < /code> from 2D Joints (and < code > break_force < /code> and < code > break_torque < /code>

After:

- Expose `get_reaction_force` and `get_reaction_torque` from 2D Joints (and `break_force` and `break_torque`)